### PR TITLE
Implement auto-scheduled task listing

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { version = "1.0", features = ["full"] }
 clap_complete = "4.5.50"
 chrono = "0.4"
 regex = "1"
+prettytable-rs = "0.10"

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -95,6 +95,10 @@ pub struct Task {
     pub kind: String,
     pub status: Option<String>,
     pub priority: Option<i32>,
+    pub deadline: Option<String>,
+    pub start_time: Option<String>,
+    pub scheduled_for: Option<String>,
+    pub category: Option<Category>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary
- add prettytable for CLI output
- enrich CLI Task model with due date fields
- trigger auto-schedule before listing tasks and wait for completion
- display tasks in a table ordered by due date

## Testing
- `cargo build --manifest-path cli/Cargo.toml`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684506491c78832293a52d83b26f208f