### PR TITLE
Improve calendar sync

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -95,6 +95,8 @@ pub struct Task {
     pub kind: String,
     pub status: Option<String>,
     pub priority: Option<i32>,
+    pub estimate: Option<i32>,
+    pub duration: Option<i32>,
     pub deadline: Option<String>,
     pub start_time: Option<String>,
     pub scheduled_for: Option<String>,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ google-auth-oauthlib~=1.2.1
 google-api-python-client~=2.169.0
 uliweb-alembic~=0.6.9
 python-dotenv~=1.1.0
+httpx~=0.27.0
+orjson~=3.10.1


### PR DESCRIPTION
## Summary
- add httpx and orjson dependencies
- embed task metadata in Google Calendar event descriptions
- handle bidirectional Google Calendar synchronization

## Testing
- `cargo check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684509eda1808322a8f361ef511f84fd